### PR TITLE
Refactor cost calculation to be line-item based

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pandas
 openpyxl
-tqdm


### PR DESCRIPTION
This change modifies the core logic of the Shopify order processor to calculate costs for each line item individually, rather than at the order level. This provides a more transparent and detailed cost breakdown in the output report.

Key changes:
- The `calculate_costs` function now adds `Piece Cost`, `SKU Cost`, and `Line Total Cost` columns for each billable line item.
- The `Cost Calculation` sheet in the Excel report has been updated to display this new line-item-level detail, with a `TOTAL` row summarizing each order.
- The `Final Invoice` sheet is updated to correctly aggregate the new line-item costs into a grand total.

Bug Fixes:
- Corrects a bug where the `TOTAL` row for an order could appear before its line items. Data is now sorted by order name before totals are added.
- Fixes an issue where the thick border separating orders was sometimes applied to the wrong row. The border is now correctly applied to the bottom of the `TOTAL` row.

Cleanup:
- Removes the unused `tqdm` dependency from `requirements.txt`.