### PR TITLE
fix: Add robust handling for missing Lineitem quantity values

### DIFF
--- a/shopify_order_processor.py
+++ b/shopify_order_processor.py
@@ -88,7 +88,7 @@ def load_and_validate_csv(file_path):
 
     dtype_map = {
         'Subtotal': float, 'Shipping': float, 'Taxes': float, 'Total': float,
-        'Discount Amount': float, 'Lineitem quantity': int, 'Lineitem price': float,
+        'Discount Amount': float, 'Lineitem price': float,
         'Lineitem compare at price': float, 'Lineitem requires shipping': bool,
         'Lineitem taxable': bool, 'Refunded Amount': float, 'Outstanding Balance': float,
         'Id': float, 'Lineitem discount': float, 'Tax 1 Value': float, 'Tax 2 Value': float,
@@ -114,6 +114,10 @@ def load_and_validate_csv(file_path):
     # Strip whitespace from 'Name' column to prevent grouping errors
     if 'Name' in df.columns:
         df['Name'] = df['Name'].astype(str).str.strip()
+
+    # Robustly handle 'Lineitem quantity' column
+    if 'Lineitem quantity' in df.columns:
+        df['Lineitem quantity'] = pd.to_numeric(df['Lineitem quantity'], errors='coerce').fillna(0).astype(int)
 
 
     logging.info("Successfully loaded and validated the input file.")


### PR DESCRIPTION
This commit fixes a `ValueError` that occurred when the input CSV file contained rows with missing data in the 'Lineitem quantity' column.

The `load_and_validate_csv` function was modified to make the data loading process more robust. Previously, it attempted to cast the column to an integer type directly during the `read_csv` call, which would fail if any non-integer values (like `NaN`) were present.

The new logic first loads the data without strict type enforcement on this column. It then uses `pd.to_numeric` to coerce all values to a numeric type, fills any resulting `NaN` values with `0`, and only then converts the column to the final `int` type. This ensures that malformed or incomplete rows do not crash the script.